### PR TITLE
v0.3.0: counts_MIN fix, torch.compile fallback, pixel_mask in results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,11 +108,33 @@ See `docs/plans/100-percent-matching-roadmap.md` for detailed investigation.
 
 ## Tutorial
 
-The tutorial is a marimo notebook at `examples/tutorial.py`, exported to `docs/tutorial.html`.
+The tutorial is a marimo notebook at `examples/tutorial.py`, exported to `examples/tutorial.html`.
 
-**Rendering**: Do NOT use `--no-include-code` — it strips plot outputs (image/png data) from the static HTML:
+### Marimo gotchas
+
+**Figures in static HTML export**: `plt.show()` does NOT produce capturable output in marimo's static export. The figure must be the **last expression** in the cell (like a return value), and it must use a **non-underscore name** (underscore-prefixed variables are cell-private in marimo and won't be rendered):
+
+```python
+# WRONG — no output in static HTML
+_fig, _ax = plt.subplots()
+_ax.plot(x, y)
+plt.show()
+return
+
+# CORRECT — figure rendered in static HTML
+fig_plot, ax_plot = plt.subplots()
+ax_plot.plot(x, y)
+fig_plot  # last expression, non-underscore name
+```
+
+**Underscore-prefixed names are cell-private**: Functions/variables starting with `_` (e.g., `_fig`, `_detect_ct_col`) are NOT exported from a cell to other cells or to static HTML output.
+
+**Deprecated matplotlib API**: Use `plt.colormaps.get_cmap('tab20').resampled(n)` instead of `plt.cm.get_cmap('tab20', n)` (deprecated in matplotlib 3.7+).
+
+### Rendering
+
 ```bash
-uv run marimo export html examples/tutorial.py -o docs/tutorial.html
+uv run marimo export html examples/tutorial.py -o examples/tutorial.html --no-include-code
 ```
 
 **Spot class encoding** is 0-indexed (unlike R spacexr which is 1-indexed):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,39 @@ Tests use `torch.compile(dynamic=True)` which has a ~60s JIT warmup on first run
 
 - `test_batch_matches_single` uses `atol=5e-5` — batch vs single-pixel IRWLS can differ slightly due to floating-point convergence order
 
+## R spacexr Concordance
+
+### Current: 99.8% dominant type agreement (matched reference)
+
+The per-pixel IRWLS solver is **bit-identical** to R spacexr given the same `norm_profiles` and `sigma`. The remaining ~0.2% gap comes from `fit_bulk()` platform effect estimation producing slightly different normalized profiles.
+
+### Key findings (2026-03-21 comparison with XeniumSeurat SUSHI pipeline)
+
+1. **Reference preparation matters**: Using a different reference (e.g. full Seurat object vs pre-downsampled spacexr Reference) drops agreement to ~95%. Always use the SAME reference cells for fair comparisons.
+2. **Weight normalization**: spacexr stores `normalize_weights()` output (sum=1, clipped [0,1]). rctd-py stores raw full-mode weights in `obsm["rctd_weights"]`. **Always normalize rctd-py weights before comparing.**
+3. **`_longdouble_sum` in `_normalize.py`**: Uses 80-bit extended precision for `bulk_Y`/`bulk_nUMI` sums, matching R's long double accumulation on x86-64. Zero performance impact.
+4. **Cell type naming**: R spacexr/zarr may normalize names (e.g. `L2/3 IT` → `L2_3 IT`). Always normalize names before comparing.
+
+### Concordance testing
+
+Full comparison report and scripts in `paul-scripts/Internal_Dev/rctd_comparison/`.
+See `docs/plans/100-percent-matching-roadmap.md` for detailed investigation.
+
+## Tutorial
+
+The tutorial is a marimo notebook at `examples/tutorial.py`, exported to `docs/tutorial.html`.
+
+**Rendering**: Do NOT use `--no-include-code` — it strips plot outputs (image/png data) from the static HTML:
+```bash
+uv run marimo export html examples/tutorial.py -o docs/tutorial.html
+```
+
+**Spot class encoding** is 0-indexed (unlike R spacexr which is 1-indexed):
+```
+0 = reject, 1 = singlet, 2 = doublet_certain, 3 = doublet_uncertain
+```
+Use `SPOT_CLASS_NAMES` from `rctd._types` (exported in public API) — never hardcode the mapping.
+
 ## CI
 
 CI runs `ruff check src/ tests/` AND `ruff format --check src/ tests/`. Both must pass. Always run both locally before pushing:

--- a/docs/plans/100-percent-matching-roadmap.md
+++ b/docs/plans/100-percent-matching-roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap: 100% Concordance with R spacexr
 
-**Date:** 2026-03-05
-**Current concordance:** 99.73% dominant type agreement (Xenium Region 1, 13,936 pixels, K=45, doublet mode)
+**Date:** 2026-03-05 (updated 2026-03-21)
+**Current concordance:** 99.77% dominant type agreement (Xenium Mouse Brain, 135,529 pixels, K=22, doublet mode, matched reference)
 **With R's intermediates injected:** 100.00% (0 disagreeing pixels)
 
 ---
@@ -45,30 +45,62 @@ The per-pixel IRWLS produces **bit-identical** weights to R spacexr given the sa
 
 ---
 
+## External Validation (2026-03-21)
+
+### XeniumSeurat (SUSHI) Comparison — p41033
+
+Compared rctd-py output against spacexr results from the FGCZ XeniumSeurat SUSHI pipeline on Xenium Mouse Brain data (Cas1_Region1, 141,668 cells, 22 cell types from Allen cortex reference).
+
+#### Key Finding: Reference Preparation Matters
+
+The XeniumSeurat app used `allen_cortex_rctd.rds` (pre-built spacexr Reference, 6,675 downsampled cells). When rctd-py used the full `allen_cortex.rds` (14,249 cells, auto-subsampled to ~10,000), agreement was lower than expected due to different reference cell composition.
+
+| Metric | Mismatched ref (14k→10k cells) | Matched ref (6,675 cells) |
+|--------|-------------------------------|---------------------------|
+| Spot class agreement | 90.3% | **99.0%** |
+| Dominant type (all classified) | 95.7% | **99.8%** |
+| Singlet-singlet agreement | 98.3% | **99.9%** |
+| Per-type weight r (mean) | — | **0.9999** |
+| Per-pixel weight r (median) | 0.997 | **0.9999** |
+
+#### Important: Weight Normalization
+
+spacexr stores **normalized** weights (`normalize_weights()` → sum=1, clipped to [0,1]).
+rctd-py stores **raw** full-mode weights (`obsm["rctd_weights"]` → sum < 1).
+
+When comparing weights, **always normalize rctd-py weights first** to avoid artificially low correlations (~0.96 unnormalized vs ~0.999 normalized).
+
+#### Report
+
+Full comparison report: `p41033/Analyses_Paul/rctd_comparison/rctd_comparison_Cas1_Region1.html`
+
+---
+
 ## Current Status
 
-### Already Implemented
+### Implemented
 - `quadprog` optional dependency with `solver` config parameter (`"auto"`, `"quadprog"`, `"gauss_seidel"`)
 - `sigma_override` parameter in `run_rctd()` and `RCTD.fit_platform_effects()` for injecting R's sigma
+- **`longdouble` accumulation in `fit_bulk()`** — uses 80-bit extended precision for the critical `bulk_Y` and `bulk_nUMI` sums, matching R's long double accumulation on x86-64 (zero performance impact)
 - All 55 tests passing
 
 ### The Concordance Gap
 
-The 37/13,936 (0.27%) disagreeing pixels are all **close-margin** cases where two cell types have weights within ~0.01-0.05 of each other. The platform effect shift causes the dominant type to flip for these borderline pixels.
+The remaining ~0.2% disagreeing pixels are **close-margin** cases where two cell types have weights within ~0.01-0.05 of each other. The platform effect shift causes the dominant type to flip for these borderline pixels.
+
+The `longdouble` fix in `_normalize.py` eliminates one source of divergence (the N-pixel sum accumulation order). However, the IRWLS solver itself uses torch operations whose accumulation order still depends on BLAS. For the small IRWLS in fit_bulk (G=153, K=22), this residual difference is typically below the sigma quantization threshold.
 
 ---
 
 ## Remaining Improvement Options
 
-### Option A: Match R's fit_bulk precision (Hard, diminishing returns)
+### Option A: Match R's fit_bulk precision — PARTIALLY IMPLEMENTED
 
-The Gaussian IRWLS in `fit_bulk()` uses `bulk_mode=True` with log operations on summed counts across ~14k cells. Matching R's floating-point behavior exactly would require:
-1. Ensuring identical operation order for `torch.log(prediction)` vs R's `log(prediction)`
-2. Matching R's matrix multiplication precision (BLAS differences)
-3. This is fundamentally limited by CPU/GPU arithmetic differences
+The `_longdouble_sum()` helper (added 2026-03-21) uses `np.longdouble` for the critical column sums in `fit_bulk()`. On x86-64, this gives 80-bit extended precision (18 significant digits), matching R's internal `sum()`.
 
-**Expected improvement:** 99.73% → ~99.9%
-**Effort:** High, and inherently fragile across hardware
+**What's still different:** The IRWLS iterations within `fit_bulk()` use torch matmul/log operations which may accumulate differently from R. Since this operates on small tensors (G=153, K=22), the residual error is typically < 1 ULP.
+
+**To fully close the gap:** The remaining IRWLS operations in `fit_bulk()` could also be promoted to longdouble. This would require converting the entire solve_irwls loop to numpy/longdouble (since PyTorch doesn't support float128). Since fit_bulk runs only once and on small tensors, the performance impact would be negligible (~10ms).
 
 ### Option B: Export R's norm_profiles as reference (Easy, 100% match)
 
@@ -81,9 +113,9 @@ For users who need exact R concordance:
 **Expected improvement:** 100.00% guaranteed
 **Effort:** Small (add `norm_profiles_override` parameter)
 
-### Option C: Accept 99.73% as sufficient (No effort)
+### Option C: Accept 99.8% as sufficient (No effort)
 
-The 0.27% gap affects only borderline pixels where two cell types are within ~0.01 weight of each other. These are genuinely ambiguous assignments that could go either way. The practical impact on downstream analysis is negligible.
+The 0.2% gap affects only borderline pixels where two cell types are within ~0.01 weight of each other. These are genuinely ambiguous assignments that could go either way. The practical impact on downstream analysis is negligible.
 
 ---
 
@@ -106,6 +138,10 @@ The original hypothesis was that `np.linalg.inv(M)` for the 437×437 tridiagonal
 ### 3. Doublet Pair Selection Ties — INVALIDATED (indirectly)
 
 Since the per-pixel IRWLS is bit-identical with R's inputs, tie-breaking cannot diverge when given the same upstream values.
+
+### 4. Reference Mismatch as Solver Bug — INVALIDATED (2026-03-21)
+
+Initial comparison with XeniumSeurat showed ~95.7% agreement. This was NOT a solver issue — it was caused by using a different reference (14k raw cells vs 6,675 pre-downsampled). With the matched reference: 99.8% agreement.
 
 ---
 

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -308,22 +308,21 @@ def _(mo):
 @app.cell
 def _(cell_type_names, plt, spatial_adata, t_doublet, t_full, t_multi):
     # --- Plot 1: Runtime comparison ---
-    _fig, _ax = plt.subplots(figsize=(6, 3))
+    fig_runtime, ax_runtime = plt.subplots(figsize=(6, 3))
     modes = ['full', 'doublet', 'multi']
     times = [t_full, t_doublet, t_multi]
     colors = ['#4C78A8', '#F58518', '#54A24B']
-    bars = _ax.barh(modes, times, color=colors, edgecolor='white', height=0.5)
-    _ax.bar_label(bars, fmt='%.1fs', padding=4, fontsize=10)
-    _ax.set_xlabel('Time (seconds)')
+    bars = ax_runtime.barh(modes, times, color=colors, edgecolor='white', height=0.5)
+    ax_runtime.bar_label(bars, fmt='%.1fs', padding=4, fontsize=10)
+    ax_runtime.set_xlabel('Time (seconds)')
     n_beads = spatial_adata.n_obs
     n_genes = spatial_adata.n_vars
     n_types = len(cell_type_names)
-    _ax.set_title(f'RCTD Runtime by Mode\n({n_beads} beads, {n_genes} genes, {n_types} cell types)')
-    _ax.set_xlim(0, max(times) * 1.35)
-    _ax.spines[['top', 'right']].set_visible(False)
+    ax_runtime.set_title(f'RCTD Runtime by Mode\n({n_beads} beads, {n_genes} genes, {n_types} cell types)')
+    ax_runtime.set_xlim(0, max(times) * 1.35)
+    ax_runtime.spines[['top', 'right']].set_visible(False)
     plt.tight_layout()
-    plt.show()
-    return
+    fig_runtime
 
 
 @app.cell(hide_code=True)
@@ -346,20 +345,20 @@ def _(
     result_multi,
     spatial_adata,
 ):
-    _fig, axes = plt.subplots(1, 3, figsize=(16, 5))
+    fig_spatial, axes = plt.subplots(1, 3, figsize=(16, 5))
     x = spatial_adata.obs['x'].values
     y = spatial_adata.obs['y'].values
-    cmap = plt.cm.get_cmap('tab20', len(cell_type_names))
+    cmap = plt.colormaps.get_cmap('tab20').resampled(len(cell_type_names))
     sc = axes[0].scatter(x, y, c=dominant_idx, cmap=cmap, vmin=-0.5, vmax=len(cell_type_names) - 0.5, s=30, alpha=0.9, edgecolors='none')
     axes[0].set_title('Full mode\n(dominant cell type)')
     axes[0].set_aspect('equal')
     axes[0].set_xlabel('x')
     axes[0].set_ylabel('y')
-    _class_colors = {0: '#888888', 1: '#4C78A8', 2: '#F58518', 3: '#E45756'}
-    for _cls, color in _class_colors.items():
-        mask = result_doublet.spot_class == _cls
+    class_colors = {0: '#888888', 1: '#4C78A8', 2: '#F58518', 3: '#E45756'}
+    for cls_id, color in class_colors.items():
+        mask = result_doublet.spot_class == cls_id
         if mask.any():
-            axes[1].scatter(x[mask], y[mask], c=color, s=30, alpha=0.9, edgecolors='none', label=class_labels[_cls])
+            axes[1].scatter(x[mask], y[mask], c=color, s=30, alpha=0.9, edgecolors='none', label=class_labels[cls_id])
     axes[1].set_title('Doublet mode\n(spot class)')
     axes[1].set_aspect('equal')
     axes[1].set_xlabel('x')
@@ -371,8 +370,7 @@ def _(
     plt.colorbar(sc2, ax=axes[2], ticks=[1, 2, 3, 4], label='# types')
     plt.suptitle('RCTD Spatial Deconvolution — Slide-seq Cerebellum', fontsize=13, y=1.01)
     plt.tight_layout()
-    plt.show()
-    return
+    fig_spatial
 
 
 @app.cell(hide_code=True)
@@ -394,16 +392,15 @@ def _(cell_type_names, dominant_idx, np, plt, result_full):
     # Show only cell types with mean weight > 1%
     active_names = [cell_type_names[_i] for _i in range(len(cell_type_names)) if active_mask[_i]]
     active_weights = result_full.weights[order][:, active_mask]
-    _fig, _ax = plt.subplots(figsize=(10, 5))
-    im = _ax.imshow(active_weights.T, aspect='auto', cmap='YlOrRd', vmin=0, vmax=1)
-    _ax.set_yticks(range(len(active_names)))
-    _ax.set_yticklabels(active_names, fontsize=9)
-    _ax.set_xlabel('Beads (sorted by dominant type)')
-    _ax.set_title('Full Mode — Cell Type Weights per Bead')
-    plt.colorbar(im, ax=_ax, label='Weight', shrink=0.8)
+    fig_heatmap, ax_heatmap = plt.subplots(figsize=(10, 5))
+    im = ax_heatmap.imshow(active_weights.T, aspect='auto', cmap='YlOrRd', vmin=0, vmax=1)
+    ax_heatmap.set_yticks(range(len(active_names)))
+    ax_heatmap.set_yticklabels(active_names, fontsize=9)
+    ax_heatmap.set_xlabel('Beads (sorted by dominant type)')
+    ax_heatmap.set_title('Full Mode — Cell Type Weights per Bead')
+    plt.colorbar(im, ax=ax_heatmap, label='Weight', shrink=0.8)
     plt.tight_layout()
-    plt.show()
-    return
+    fig_heatmap
 
 
 @app.cell(hide_code=True)

--- a/src/rctd/_doublet.py
+++ b/src/rctd/_doublet.py
@@ -29,6 +29,7 @@ def run_doublet_mode(
     config: RCTDConfig,
     batch_size: int = 10000,
     device: str = "auto",
+    pixel_mask: np.ndarray | None = None,
 ) -> DoubletResult:
     """Run doublet mode deconvolution.
 
@@ -408,4 +409,5 @@ def run_doublet_mode(
         min_score=min_score,
         singlet_score=singlet_score_res,
         cell_type_names=cell_type_names,
+        pixel_mask=pixel_mask,
     )

--- a/src/rctd/_full.py
+++ b/src/rctd/_full.py
@@ -17,6 +17,7 @@ def run_full_mode(
     x_vals: np.ndarray,
     batch_size: int = 10000,
     device: str = "auto",
+    pixel_mask: np.ndarray | None = None,
 ) -> FullResult:
     """Run full mode deconvolution across all spatial pixels.
 
@@ -78,4 +79,5 @@ def run_full_mode(
         weights=final_weights,
         cell_type_names=cell_type_names,
         converged=final_converged,
+        pixel_mask=pixel_mask,
     )

--- a/src/rctd/_irwls.py
+++ b/src/rctd/_irwls.py
@@ -268,6 +268,29 @@ def _psd_2x2(H: torch.Tensor, epsilon: float = 1e-3) -> tuple[torch.Tensor, torc
     return H_psd, lam2
 
 
+# cuSOLVER's batched syevBatched has an undocumented batch-size limit on
+# certain GPU architectures (e.g. Blackwell / compute capability 12.0,
+# confirmed with CUDA 12.8 + PyTorch 2.9).  The exact threshold depends on K
+# (e.g. ~31650 for K=3, ~27430 for K=16) but stays above 27000 for K≤16.
+# We sub-batch eigh calls at 25000 to stay safely below the limit for all K.
+_MAX_EIGH_BATCH: int = 25000
+
+
+def _eigh_safe(H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """torch.linalg.eigh with sub-batching to avoid cuSOLVER batch-size limits."""
+    N = H.shape[0]
+    if N <= _MAX_EIGH_BATCH or H.device.type != "cuda":
+        return torch.linalg.eigh(H)
+    # Sub-batch to stay under cuSOLVER limit
+    all_evals = []
+    all_evecs = []
+    for start in range(0, N, _MAX_EIGH_BATCH):
+        evals, evecs = torch.linalg.eigh(H[start : start + _MAX_EIGH_BATCH])
+        all_evals.append(evals)
+        all_evecs.append(evecs)
+    return torch.cat(all_evals), torch.cat(all_evecs)
+
+
 def _psd_batch(H: torch.Tensor, epsilon: float = 1e-3) -> tuple[torch.Tensor, torch.Tensor]:
     """Batched PSD projection. H: (N, K, K) → (H_psd (N, K, K), max_eig (N,)).
 
@@ -294,7 +317,7 @@ def _psd_batch(H: torch.Tensor, epsilon: float = 1e-3) -> tuple[torch.Tensor, to
         if nan_mask.any():
             H = H.clone()
             H[nan_mask] = epsilon * torch.eye(K, dtype=H.dtype, device=H.device)
-        eigenvalues, eigenvectors = torch.linalg.eigh(H)
+        eigenvalues, eigenvectors = _eigh_safe(H)
         eigenvalues = torch.clamp(eigenvalues, min=epsilon)
         # Fused reconstruction: V * sqrt(λ) → (V*sqrt(λ)) @ (V*sqrt(λ))^T
         # Equivalent to V @ diag(λ) @ V^T but avoids diag_embed

--- a/src/rctd/_irwls.py
+++ b/src/rctd/_irwls.py
@@ -4,6 +4,8 @@ Ports solveIRWLS.weights, solveWLS, get_der_fast, psd from R spacexr.
 Uses PyTorch for GPU acceleration.
 """
 
+import warnings
+
 import torch
 
 from rctd._likelihood import calc_q_all
@@ -341,19 +343,17 @@ def _psd_batch(H: torch.Tensor, epsilon: float = 1e-3) -> tuple[torch.Tensor, to
         )
 
 
-@torch.compile(dynamic=True)
-def _solve_box_qp_batch_compiled(
+def _solve_box_qp_batch_impl(
     D: torch.Tensor,
     d: torch.Tensor,
     lower_bound: torch.Tensor,
     n_sweeps: int = 50,
 ) -> torch.Tensor:
-    """Compiled Gauss-Seidel coordinate descent for batched box-constrained QP.
+    """Gauss-Seidel coordinate descent for batched box-constrained QP.
 
-    torch.compile with dynamic=True fuses the inner coordinate descent
-    operations into optimized kernels via Triton/Inductor, reducing memory
-    traffic and kernel launch overhead. Dynamic shapes avoid excessive
-    recompilations when batch size N or type count K varies across calls.
+    When compiled via torch.compile(dynamic=True), fuses the inner coordinate
+    descent operations into optimized kernels via Triton/Inductor, reducing
+    memory traffic and kernel launch overhead.
     """
     K = d.shape[1]
     D_diag = torch.diagonal(D, dim1=-2, dim2=-1)  # (N, K)
@@ -366,6 +366,15 @@ def _solve_box_qp_batch_compiled(
             x[:, i] = torch.maximum(residual / D[:, i, i], lower_bound[:, i])
 
     return x
+
+
+# Lazy-compile state: None = not yet attempted, True/False = cached result
+_USE_COMPILE: bool | None = None
+
+try:
+    _solve_box_qp_batch_compiled = torch.compile(_solve_box_qp_batch_impl, dynamic=True)
+except Exception:
+    _solve_box_qp_batch_compiled = None
 
 
 @torch.jit.script
@@ -445,6 +454,7 @@ def _solve_box_qp_batch(
 
     For K=2, uses analytical closed-form (no iterative sweeps needed).
     Otherwise, Gauss-Seidel coordinate descent, vectorized across pixels.
+    Uses torch.compile when available; auto-falls back to eager on failure.
 
     Args:
         D: (N, K, K) PSD matrices
@@ -458,7 +468,28 @@ def _solve_box_qp_batch(
     K = d.shape[1]
     if K == 2:
         return _solve_box_qp_2(D, d, lower_bound)
-    return _solve_box_qp_batch_compiled(D, d, lower_bound, n_sweeps)
+
+    global _USE_COMPILE
+    if _USE_COMPILE is False or _solve_box_qp_batch_compiled is None:
+        return _solve_box_qp_batch_impl(D, d, lower_bound, n_sweeps)
+
+    if _USE_COMPILE is True:
+        return _solve_box_qp_batch_compiled(D, d, lower_bound, n_sweeps)
+
+    # First call: try compiled, fall back to eager
+    try:
+        result = _solve_box_qp_batch_compiled(D, d, lower_bound, n_sweeps)
+        _USE_COMPILE = True
+        return result
+    except RuntimeError:
+        _USE_COMPILE = False
+        warnings.warn(
+            "torch.compile failed for box-QP solver (missing CUDA headers or Triton); "
+            "falling back to eager mode. Use RCTDConfig(compile=False) to suppress.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _solve_box_qp_batch_impl(D, d, lower_bound, n_sweeps)
 
 
 @torch.no_grad()

--- a/src/rctd/_likelihood.py
+++ b/src/rctd/_likelihood.py
@@ -5,10 +5,9 @@ from prob_model.R.
 """
 
 import urllib.request
+import warnings
 import zipfile
 from pathlib import Path
-
-import warnings
 
 import numpy as np
 import torch

--- a/src/rctd/_likelihood.py
+++ b/src/rctd/_likelihood.py
@@ -8,6 +8,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
+import warnings
+
 import numpy as np
 import torch
 from scipy.special import gammaln
@@ -304,11 +306,52 @@ def _calc_q_all_impl(
     return d0_vec, d1_vec, d2_vec
 
 
-# Compiled version for hot-path deconvolution (IRWLS solver)
-calc_q_all = torch.compile(_calc_q_all_impl, dynamic=True)
-
 # Eager version for sigma estimation (small batches, compilation not amortized)
 calc_q_all_eager = _calc_q_all_impl
+
+# Lazy-compile state: None = not yet attempted, True/False = cached result
+_CALC_Q_USE_COMPILE: bool | None = None
+
+try:
+    _calc_q_all_compiled = torch.compile(_calc_q_all_impl, dynamic=True)
+except Exception:
+    _calc_q_all_compiled = None
+
+
+def calc_q_all(
+    Y: torch.Tensor,
+    lam: torch.Tensor,
+    Q_mat: torch.Tensor,
+    SQ_mat: torch.Tensor,
+    x_vals: torch.Tensor,
+    K_val: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute Q derivatives, using torch.compile when available.
+
+    Auto-detects compilation failures on first call and falls back to eager.
+    """
+    global _CALC_Q_USE_COMPILE
+    if _CALC_Q_USE_COMPILE is False or _calc_q_all_compiled is None:
+        return _calc_q_all_impl(Y, lam, Q_mat, SQ_mat, x_vals, K_val)
+
+    if _CALC_Q_USE_COMPILE is True:
+        return _calc_q_all_compiled(Y, lam, Q_mat, SQ_mat, x_vals, K_val)
+
+    # First call: try compiled, fall back to eager
+    try:
+        result = _calc_q_all_compiled(Y, lam, Q_mat, SQ_mat, x_vals, K_val)
+        _CALC_Q_USE_COMPILE = True
+        return result
+    except RuntimeError:
+        _CALC_Q_USE_COMPILE = False
+        warnings.warn(
+            "torch.compile failed for likelihood computation (missing CUDA headers "
+            "or Triton); falling back to eager mode. "
+            "Use RCTDConfig(compile=False) to suppress.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _calc_q_all_impl(Y, lam, Q_mat, SQ_mat, x_vals, K_val)
 
 
 def calc_log_likelihood(

--- a/src/rctd/_multi.py
+++ b/src/rctd/_multi.py
@@ -140,6 +140,7 @@ def run_multi_mode(
     config: RCTDConfig,
     batch_size: int = 10000,
     device: str = "auto",
+    pixel_mask: np.ndarray | None = None,
 ) -> MultiResult:
     """Run multi mode deconvolution.
 
@@ -351,4 +352,5 @@ def run_multi_mode(
         conf_list=conf_list_arr,
         min_score=min_score,
         cell_type_names=cell_type_names,
+        pixel_mask=pixel_mask,
     )

--- a/src/rctd/_normalize.py
+++ b/src/rctd/_normalize.py
@@ -1,8 +1,22 @@
 from typing import Tuple
 
+import numpy as np
 import torch
 
 from rctd._irwls import solve_irwls
+
+
+def _longdouble_sum(t: torch.Tensor, dim: int) -> torch.Tensor:
+    """Sum a tensor along a dimension using longdouble accumulation.
+
+    On x86-64, this uses 80-bit extended precision (18 significant digits),
+    matching R's internal sum() which also uses long double on this platform.
+    This eliminates BLAS-order-dependent floating-point divergence between
+    R and Python for large reductions (e.g. summing 135k spatial pixels).
+    """
+    arr = t.detach().cpu().numpy()
+    result = arr.astype(np.longdouble).sum(axis=dim).astype(np.float64)
+    return torch.tensor(result, dtype=t.dtype, device=t.device)
 
 
 def fit_bulk(
@@ -31,10 +45,12 @@ def fit_bulk(
     dtype = cell_type_profiles.dtype
 
     # Sum counts across all pixels (N, G) -> (G,)
-    bulk_Y = torch.sum(spatial_counts, dim=0)
+    # Use longdouble accumulation to match R's long double precision,
+    # eliminating BLAS-order-dependent divergence in platform effects.
+    bulk_Y = _longdouble_sum(spatial_counts, dim=0)
 
     # Total UMI across all pixels
-    bulk_nUMI = torch.sum(spatial_nUMI)
+    bulk_nUMI = _longdouble_sum(spatial_nUMI, dim=0)
 
     # Scale reference profiles to bulk nUMI
     bulk_S = cell_type_profiles * bulk_nUMI

--- a/src/rctd/_rctd.py
+++ b/src/rctd/_rctd.py
@@ -43,6 +43,13 @@ class RCTD:
         self.reference = reference
         self.config = config if config is not None else RCTDConfig()
 
+        # Disable torch.compile if requested
+        if not self.config.compile:
+            from rctd import _irwls, _likelihood
+
+            _irwls._USE_COMPILE = False
+            _likelihood._CALC_Q_USE_COMPILE = False
+
         # Internal state
         self.is_normalized = False
         self.norm_profiles = None

--- a/src/rctd/_rctd.py
+++ b/src/rctd/_rctd.py
@@ -329,6 +329,7 @@ def run_rctd(
         "x_vals": rctd.x_vals,
         "batch_size": batch_size,
         "device": rctd.config.device,
+        "pixel_mask": rctd._pixel_mask,
     }
 
     if mode == "full":

--- a/src/rctd/_rctd.py
+++ b/src/rctd/_rctd.py
@@ -164,13 +164,36 @@ class RCTD:
             f"(from {len(self.common_genes)} common)"
         )
 
-        # ── 2. fitBulk on gene_list_bulk ──
+        # ── 2. counts_MIN filter on gene_list_bulk (R: second restrict_counts) ──
+        # R computes colSums(counts[gene_list_bulk, ]) per pixel and removes
+        # pixels where this sum < counts_MIN. A pixel may have high total UMI
+        # but very few counts in the DE gene set.
+        bulk_gene_idx = [self.common_genes.index(g) for g in gene_list_bulk]
+        bulk_counts = self.counts[:, bulk_gene_idx]
+
+        if self.config.counts_MIN > 0:
+            counts_in_bulk = bulk_counts.sum(axis=1)
+            counts_mask = counts_in_bulk >= self.config.counts_MIN
+            n_before = len(counts_mask)
+            n_removed = int((~counts_mask).sum())
+            if n_removed > 0:
+                self.counts = self.counts[counts_mask]
+                self.nUMI = self.nUMI[counts_mask]
+                bulk_counts = bulk_counts[counts_mask]
+                # Update _pixel_mask: narrow the True entries
+                true_indices = np.where(self._pixel_mask)[0]
+                self._pixel_mask[true_indices[~counts_mask]] = False
+                print(
+                    f"counts_MIN filter: removed {n_removed}/{n_before} pixels "
+                    f"with <{self.config.counts_MIN} counts in bulk gene list"
+                )
+
+        # ── 3. fitBulk on gene_list_bulk ──
+        # (Step 2 above may have removed pixels, so bulk_counts is updated)
         # R: fitBulk uses puck@counts (restricted to gene_list_bulk) and
         #    puck@nUMI (total across ALL original genes, never recomputed)
         print("Fitting bulk platform effects...")
         bulk_profiles = self.reference.get_profiles_for_genes(gene_list_bulk)
-        bulk_gene_idx = [self.common_genes.index(g) for g in gene_list_bulk]
-        bulk_counts = self.counts[:, bulk_gene_idx]
 
         bulk_weights, norm_prof_bulk = fit_bulk(
             cell_type_profiles=torch.tensor(bulk_profiles, device=device),
@@ -179,7 +202,7 @@ class RCTD:
             min_change=self.config.MIN_CHANGE_BULK,
         )
 
-        # ── 3. Restrict to gene_list_reg for pixel-level fitting ──
+        # ── 4. Restrict to gene_list_reg for pixel-level fitting ──
         # Subset the bulk-normalized profiles to reg genes (matching R's approach:
         # R normalizes on gene_list_bulk via get_norm_ref, then subsets to gene_list_reg)
         norm_prof_bulk_np = norm_prof_bulk.cpu().numpy()  # (G_bulk, K)
@@ -195,7 +218,7 @@ class RCTD:
         self._gene_list_reg = gene_list_reg
         print(f"Using {len(gene_list_reg)} DE genes for pixel-level fitting")
 
-        # ── 4. choose_sigma on reg genes ──
+        # ── 5. choose_sigma on reg genes ──
         cache = load_cached_q_matrices()
         self.x_vals = cache.pop("X_vals")
         q_matrices = {k.replace("Q_", ""): v for k, v in cache.items()}

--- a/src/rctd/_reference.py
+++ b/src/rctd/_reference.py
@@ -82,12 +82,7 @@ class Reference:
             nUMI = nUMI[keep_valid]
             unique_types = valid_types
 
-        if sparse.issparse(X):
-            X = np.asarray(X.todense())
-        else:
-            X = np.asarray(X, dtype=np.float64)
-
-        # Downsample if needed
+        # Downsample if needed (keep sparse to avoid OOM on large references)
         rng = np.random.default_rng(42)
         keep_idx = []
         for ct in unique_types:
@@ -110,13 +105,19 @@ class Reference:
         # Ports get_cell_type_info from R processRef.R
         # For each cell type: normalize each cell by its UMI count, then average
         profiles = np.zeros((self.n_genes, self.n_types), dtype=np.float64)
+        is_sparse = sparse.issparse(X)
         for k, ct in enumerate(unique_types):
             mask = cell_types == ct
             ct_data = X[mask]  # (n_cells_k, G)
-            ct_nUMI = nUMI[mask]  # (n_cells_k,)
-            # sweep(cell_type_data, 2, cell_type_umi, `/`) then rowSums / ncol
-            normed = ct_data / ct_nUMI[:, None]
-            profiles[:, k] = normed.mean(axis=0)
+            ct_nUMI = nUMI[mask].astype(np.float64)  # (n_cells_k,)
+            if is_sparse:
+                # mean(X / nUMI) = X.T @ (1/nUMI) / n_cells
+                # Sparse mat-vec product avoids materializing a dense matrix.
+                profiles[:, k] = ct_data.T.dot(1.0 / ct_nUMI) / len(ct_nUMI)
+            else:
+                ct_data = np.asarray(ct_data, dtype=np.float64)
+                normed = ct_data / ct_nUMI[:, None]
+                profiles[:, k] = normed.mean(axis=0)
 
         self.profiles = profiles  # (G, K), columns sum to ~1
 

--- a/src/rctd/_types.py
+++ b/src/rctd/_types.py
@@ -30,6 +30,7 @@ class RCTDConfig(NamedTuple):
     K_val: int = 1000
     dtype: str = "float64"  # "float32" or "float64"; float32 saves GPU memory
     device: str = "auto"  # "auto", "cpu", or "cuda"; auto uses GPU if available
+    compile: bool = True  # Use torch.compile; False forces eager mode
 
 
 def resolve_device(device: str = "auto") -> torch.device:

--- a/src/rctd/_types.py
+++ b/src/rctd/_types.py
@@ -80,6 +80,7 @@ class FullResult(NamedTuple):
     weights: np.ndarray  # (N, K) float32
     cell_type_names: list[str]
     converged: np.ndarray  # (N,) bool
+    pixel_mask: np.ndarray | None = None  # (N_total,) bool — which pixels passed filtering
 
 
 class DoubletResult(NamedTuple):
@@ -95,6 +96,7 @@ class DoubletResult(NamedTuple):
     min_score: np.ndarray  # (N,) float
     singlet_score: np.ndarray  # (N,) float
     cell_type_names: list[str]
+    pixel_mask: np.ndarray | None = None  # (N_total,) bool — which pixels passed filtering
 
 
 class MultiResult(NamedTuple):
@@ -107,6 +109,7 @@ class MultiResult(NamedTuple):
     conf_list: np.ndarray  # (N, MAX_MULTI_TYPES) bool
     min_score: np.ndarray  # (N,) float
     cell_type_names: list[str]
+    pixel_mask: np.ndarray | None = None  # (N_total,) bool — which pixels passed filtering
 
 
 # Spot class encoding

--- a/src/rctd/cli.py
+++ b/src/rctd/cli.py
@@ -387,6 +387,12 @@ def _write_results_to_adata(
 @click.option(
     "--device", type=click.Choice(["auto", "cpu", "cuda"]), default="auto", show_default=True
 )
+@click.option(
+    "--no-compile",
+    is_flag=True,
+    default=False,
+    help="Disable torch.compile (for environments without CUDA headers).",
+)
 # Performance
 @click.option(
     "--batch-size",
@@ -443,6 +449,7 @@ def run(
     doublet_threshold,
     dtype,
     device,
+    no_compile,
     batch_size,
     sigma_override,
     cell_min,
@@ -484,6 +491,7 @@ def run(
         DOUBLET_THRESHOLD=doublet_threshold,
         dtype=dtype,
         device=device,
+        compile=not no_compile,
     )
     config_dict = config._asdict()
 

--- a/src/rctd/cli.py
+++ b/src/rctd/cli.py
@@ -541,6 +541,7 @@ def run(
                 "x_vals": rctd_obj.x_vals,
                 "batch_size": batch_size,
                 "device": config.device,
+                "pixel_mask": rctd_obj._pixel_mask,
             }
 
             if mode == "full":
@@ -557,7 +558,7 @@ def run(
                 spatial_adata,
                 result,
                 mode,
-                rctd_obj._pixel_mask,
+                result.pixel_mask,
                 config_dict,
                 cell_type_names,
                 __version__,

--- a/tests/test_compile_fallback.py
+++ b/tests/test_compile_fallback.py
@@ -142,7 +142,6 @@ class TestConfigCompileFlag:
     def test_rctd_init_disables_compile(self, monkeypatch):
         """RCTD(config=RCTDConfig(compile=False)) sets module globals."""
         import anndata
-        import numpy as np
 
         from rctd._rctd import RCTD
         from rctd._types import RCTDConfig

--- a/tests/test_compile_fallback.py
+++ b/tests/test_compile_fallback.py
@@ -1,0 +1,176 @@
+"""Tests for torch.compile fallback behavior."""
+
+import warnings
+
+import numpy as np
+import pytest
+import torch
+
+from rctd import _irwls, _likelihood
+
+
+def _make_small_qp_problem(N=10, K=3, device="cpu"):
+    """Create a small box-QP problem for testing."""
+    # Random PSD matrices
+    A = torch.randn(N, K, K, device=device, dtype=torch.float64)
+    D = A @ A.transpose(-1, -2) + 0.1 * torch.eye(K, device=device, dtype=torch.float64)
+    d = torch.randn(N, K, device=device, dtype=torch.float64)
+    lower_bound = -torch.ones(N, K, device=device, dtype=torch.float64)
+    return D, d, lower_bound
+
+
+class TestBoxQPFallback:
+    """Tests for _solve_box_qp_batch compile fallback."""
+
+    def test_eager_matches_impl(self):
+        """Eager implementation produces correct results."""
+        D, d, lb = _make_small_qp_problem()
+        result = _irwls._solve_box_qp_batch_impl(D, d, lb)
+        assert result.shape == (10, 3)
+        assert torch.isfinite(result).all()
+
+    def test_compile_false_uses_eager(self, monkeypatch):
+        """When _USE_COMPILE is False, eager path is used."""
+        monkeypatch.setattr(_irwls, "_USE_COMPILE", False)
+        D, d, lb = _make_small_qp_problem()
+        result = _irwls._solve_box_qp_batch(D, d, lb)
+        expected = _irwls._solve_box_qp_batch_impl(D, d, lb)
+        torch.testing.assert_close(result, expected)
+
+    def test_fallback_on_runtime_error(self, monkeypatch):
+        """Auto-fallback to eager when compiled version raises RuntimeError."""
+        monkeypatch.setattr(_irwls, "_USE_COMPILE", None)
+
+        def raise_on_call(*args, **kwargs):
+            raise RuntimeError("Simulated torch.compile failure")
+
+        monkeypatch.setattr(_irwls, "_solve_box_qp_batch_compiled", raise_on_call)
+
+        D, d, lb = _make_small_qp_problem()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _irwls._solve_box_qp_batch(D, d, lb)
+            assert len(w) == 1
+            assert "torch.compile failed" in str(w[0].message)
+
+        # Verify result is correct (matches eager)
+        expected = _irwls._solve_box_qp_batch_impl(D, d, lb)
+        torch.testing.assert_close(result, expected)
+
+        # Subsequent calls should use eager without warning
+        assert _irwls._USE_COMPILE is False
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _irwls._solve_box_qp_batch(D, d, lb)
+            assert len(w) == 0
+
+    def test_k2_bypasses_compile(self):
+        """K=2 uses analytical solver, not compiled path."""
+        D, d, lb = _make_small_qp_problem(K=2)
+        result = _irwls._solve_box_qp_batch(D, d, lb)
+        assert result.shape == (10, 2)
+
+
+class TestCalcQAllFallback:
+    """Tests for calc_q_all compile fallback."""
+
+    @pytest.fixture
+    def q_inputs(self):
+        """Create minimal inputs for calc_q_all."""
+        from rctd._likelihood import load_cached_q_matrices
+
+        cache = load_cached_q_matrices()
+        x_vals = cache.pop("X_vals")
+        # Use first Q matrix
+        key = next(k for k in cache if k.startswith("Q_"))
+        Q_mat = cache[key]
+        SQ_mat = Q_mat**2  # Simplified
+        Q_t = torch.tensor(Q_mat, dtype=torch.float64)
+        SQ_t = torch.tensor(SQ_mat, dtype=torch.float64)
+        x_t = torch.tensor(x_vals, dtype=torch.float64)
+
+        Y = torch.randint(0, 50, (100,), dtype=torch.float64)
+        lam = torch.rand(100, dtype=torch.float64) * 10 + 1
+
+        return Y, lam, Q_t, SQ_t, x_t
+
+    def test_compile_false_uses_eager(self, monkeypatch, q_inputs):
+        """When _CALC_Q_USE_COMPILE is False, eager path is used."""
+        monkeypatch.setattr(_likelihood, "_CALC_Q_USE_COMPILE", False)
+        Y, lam, Q, SQ, x = q_inputs
+        result = _likelihood.calc_q_all(Y, lam, Q, SQ, x)
+        expected = _likelihood.calc_q_all_eager(Y, lam, Q, SQ, x)
+        for r, e in zip(result, expected):
+            torch.testing.assert_close(r, e)
+
+    def test_fallback_on_runtime_error(self, monkeypatch, q_inputs):
+        """Auto-fallback to eager when compiled raises RuntimeError."""
+        monkeypatch.setattr(_likelihood, "_CALC_Q_USE_COMPILE", None)
+
+        def raise_on_call(*args, **kwargs):
+            raise RuntimeError("Simulated torch.compile failure")
+
+        monkeypatch.setattr(_likelihood, "_calc_q_all_compiled", raise_on_call)
+
+        Y, lam, Q, SQ, x = q_inputs
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _likelihood.calc_q_all(Y, lam, Q, SQ, x)
+            assert len(w) == 1
+            assert "torch.compile failed" in str(w[0].message)
+
+        expected = _likelihood.calc_q_all_eager(Y, lam, Q, SQ, x)
+        for r, e in zip(result, expected):
+            torch.testing.assert_close(r, e)
+
+        assert _likelihood._CALC_Q_USE_COMPILE is False
+
+
+class TestConfigCompileFlag:
+    """Test that RCTDConfig(compile=False) disables compilation."""
+
+    def test_config_compile_default_true(self):
+        from rctd._types import RCTDConfig
+
+        assert RCTDConfig().compile is True
+
+    def test_config_compile_false(self):
+        from rctd._types import RCTDConfig
+
+        assert RCTDConfig(compile=False).compile is False
+
+    def test_rctd_init_disables_compile(self, monkeypatch):
+        """RCTD(config=RCTDConfig(compile=False)) sets module globals."""
+        import anndata
+        import numpy as np
+
+        from rctd._rctd import RCTD
+        from rctd._types import RCTDConfig
+
+        # Reset globals
+        monkeypatch.setattr(_irwls, "_USE_COMPILE", None)
+        monkeypatch.setattr(_likelihood, "_CALC_Q_USE_COMPILE", None)
+
+        # Create minimal data
+        n_cells, n_genes = 50, 100
+        ref_adata = anndata.AnnData(
+            X=np.random.poisson(5, (n_cells, n_genes)).astype(np.float32),
+            var={"_index": [f"Gene{i}" for i in range(n_genes)]},
+        )
+        ref_adata.var_names = [f"Gene{i}" for i in range(n_genes)]
+        ref_adata.obs["cell_type"] = np.random.choice(["A", "B", "C"], n_cells)
+
+        from rctd._reference import Reference
+
+        ref = Reference(ref_adata, cell_min=2)
+
+        spatial = anndata.AnnData(
+            X=np.random.poisson(10, (30, n_genes)).astype(np.float32),
+        )
+        spatial.var_names = [f"Gene{i}" for i in range(n_genes)]
+
+        config = RCTDConfig(compile=False, UMI_min=1)
+        RCTD(spatial, ref, config)
+
+        assert _irwls._USE_COMPILE is False
+        assert _likelihood._CALC_Q_USE_COMPILE is False

--- a/tests/test_counts_min.py
+++ b/tests/test_counts_min.py
@@ -1,0 +1,287 @@
+"""Tests for counts_MIN pixel filtering.
+
+R spacexr's restrict_counts() filters pixels whose total counts across the
+selected DE gene list fall below counts_MIN. This filter is applied AFTER
+gene list selection in create.RCTD(), meaning a pixel can pass the UMI_min
+filter (high total UMI) but be removed if it has very few counts in the
+DE gene set.
+
+rctd-py must replicate this behavior.
+"""
+
+import anndata
+import numpy as np
+import pytest
+
+from rctd._rctd import RCTD
+from rctd._reference import Reference
+from rctd._types import RCTDConfig
+
+
+def _make_counts_min_test_data(seed=42):
+    """Create data where some pixels pass UMI filter but fail counts_MIN on DE genes.
+
+    Strategy:
+    - 200 genes total, shared between spatial and reference
+    - Reference has 5 cell types with clear marker genes (genes 0-99)
+    - Spatial has 50 pixels:
+      - 40 'normal' pixels: spread counts across all genes (pass both filters)
+      - 10 'sparse-DE' pixels: high total UMI (>= 200) but nearly all counts
+        in genes 100-199 (non-marker genes), so counts in DE genes < counts_MIN
+    """
+    rng = np.random.default_rng(seed)
+    n_genes = 200
+    n_types = 5
+    n_pixels = 50
+    n_normal = 40
+    n_sparse = 10
+
+    gene_names = [f"Gene_{i}" for i in range(n_genes)]
+
+    # ── Reference: 5 types, 300 cells, markers in genes 0-99 ──
+    n_ref_cells = 300
+    cells_per_type = n_ref_cells // n_types
+    ref_counts = np.zeros((n_ref_cells, n_genes), dtype=np.float32)
+    cell_types = []
+    for k in range(n_types):
+        for c in range(cells_per_type):
+            idx = k * cells_per_type + c
+            # Marker genes for this type (genes k*20 to k*20+19)
+            marker_start = k * 20
+            ref_counts[idx, marker_start : marker_start + 20] = rng.poisson(50, size=20)
+            # Background across all genes
+            ref_counts[idx, :] += rng.poisson(1, size=n_genes)
+            cell_types.append(f"Type_{k}")
+
+    ref_adata = anndata.AnnData(
+        X=ref_counts,
+        obs={"cell_type": cell_types},
+    )
+    ref_adata.var_names = gene_names
+    ref_adata.obs_names = [f"RefCell_{i}" for i in range(n_ref_cells)]
+
+    # ── Spatial: 40 normal + 10 sparse-DE pixels ──
+    spatial_counts = np.zeros((n_pixels, n_genes), dtype=np.float32)
+
+    # Normal pixels: counts spread across genes including markers
+    for i in range(n_normal):
+        spatial_counts[i, :100] = rng.poisson(5, size=100)  # marker region
+        spatial_counts[i, 100:] = rng.poisson(3, size=100)  # non-marker region
+
+    # Sparse-DE pixels: high total UMI but almost all in non-marker genes
+    for i in range(n_normal, n_pixels):
+        spatial_counts[i, :100] = rng.poisson(0.05, size=100)  # ~5 total in DE genes
+        spatial_counts[i, 100:] = rng.poisson(10, size=100)  # ~1000 total in non-DE
+
+    spatial_adata = anndata.AnnData(
+        X=spatial_counts,
+        obs={"x": rng.uniform(0, 100, n_pixels), "y": rng.uniform(0, 100, n_pixels)},
+    )
+    spatial_adata.var_names = gene_names
+    spatial_adata.obs_names = [f"Pixel_{i}" for i in range(n_pixels)]
+
+    return spatial_adata, ref_adata, n_normal, n_sparse
+
+
+class TestCountsMinFilter:
+    """Test that counts_MIN filters pixels with low counts in the DE gene set."""
+
+    def test_counts_min_reduces_pixel_count(self):
+        """Pixels with high total UMI but low counts in DE genes should be filtered."""
+        spatial, ref_adata, n_normal, n_sparse = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        # With counts_MIN=10 (default), sparse-DE pixels should be filtered
+        config = RCTDConfig(UMI_min=100, counts_MIN=10)
+        rctd = RCTD(spatial, reference, config)
+        rctd.fit_platform_effects()
+
+        # The sparse-DE pixels have ~5 total counts in the DE gene region,
+        # so they should fail the counts_MIN=10 filter.
+        # Total pixels passing UMI filter first:
+        total_umi = spatial.X.sum(axis=1)
+        n_pass_umi = int((total_umi >= 100).sum())
+
+        # After counts_MIN, we should have fewer pixels
+        n_after_counts_min = rctd.counts.shape[0]
+        assert n_after_counts_min < n_pass_umi, (
+            f"counts_MIN filter had no effect: {n_after_counts_min} pixels "
+            f"(same as UMI-only filter: {n_pass_umi}). "
+            f"Expected some sparse-DE pixels to be removed."
+        )
+
+    def test_counts_min_zero_disables_filter(self):
+        """Setting counts_MIN=0 should keep all UMI-passing pixels."""
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        # counts_MIN=0 should disable the gene-list filter
+        config_no_filter = RCTDConfig(UMI_min=100, counts_MIN=0)
+        rctd_no = RCTD(spatial, reference, config_no_filter)
+        rctd_no.fit_platform_effects()
+
+        total_umi = spatial.X.sum(axis=1)
+        n_pass_umi = int((total_umi >= 100).sum())
+
+        assert rctd_no.counts.shape[0] == n_pass_umi, (
+            f"counts_MIN=0 should keep all UMI-passing pixels, "
+            f"got {rctd_no.counts.shape[0]} vs {n_pass_umi}"
+        )
+
+    def test_pixel_mask_updated_after_counts_min(self):
+        """_pixel_mask should reflect counts_MIN filtering for CLI output alignment."""
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+        config = RCTDConfig(UMI_min=100, counts_MIN=10)
+        rctd = RCTD(spatial, reference, config)
+        rctd.fit_platform_effects()
+
+        # _pixel_mask should have exactly as many True values as pixels in counts
+        assert rctd._pixel_mask.sum() == rctd.counts.shape[0], (
+            f"_pixel_mask ({rctd._pixel_mask.sum()} True) doesn't match "
+            f"counts shape ({rctd.counts.shape[0]} pixels)"
+        )
+
+        # Mask should be boolean and same length as original spatial data
+        assert rctd._pixel_mask.dtype == bool
+        assert len(rctd._pixel_mask) == spatial.n_obs
+
+    def test_counts_min_1_keeps_all_nonzero(self):
+        """counts_MIN=1 should only remove pixels with zero counts in DE genes."""
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        config_1 = RCTDConfig(UMI_min=100, counts_MIN=1)
+        rctd_1 = RCTD(spatial, reference, config_1)
+        rctd_1.fit_platform_effects()
+
+        config_0 = RCTDConfig(UMI_min=100, counts_MIN=0)
+        rctd_0 = RCTD(spatial, reference, config_0)
+        rctd_0.fit_platform_effects()
+
+        # counts_MIN=1 should keep almost all pixels (very few have exactly 0
+        # counts across all DE genes), so it's >= counts_MIN=10 result
+        assert rctd_1.counts.shape[0] >= rctd_0.counts.shape[0] - 1
+        assert rctd_1.counts.shape[0] <= rctd_0.counts.shape[0]
+
+    def test_high_counts_min_filters_more(self):
+        """Higher counts_MIN should filter more pixels."""
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        config_10 = RCTDConfig(UMI_min=100, counts_MIN=10)
+        rctd_10 = RCTD(spatial, reference, config_10)
+        rctd_10.fit_platform_effects()
+
+        config_50 = RCTDConfig(UMI_min=100, counts_MIN=50)
+        rctd_50 = RCTD(spatial, reference, config_50)
+        rctd_50.fit_platform_effects()
+
+        # Higher threshold should keep fewer or equal pixels
+        assert rctd_50.counts.shape[0] <= rctd_10.counts.shape[0]
+
+    def test_numi_not_recomputed_after_filter(self):
+        """nUMI should reflect total UMI from ALL genes, not just DE genes."""
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+        config = RCTDConfig(UMI_min=100, counts_MIN=10)
+        rctd = RCTD(spatial, reference, config)
+        rctd.fit_platform_effects()
+
+        # nUMI should be total across all genes for each remaining pixel
+        total_umi_all_genes = np.array(spatial.X.sum(axis=1)).flatten()
+        kept_umi = total_umi_all_genes[rctd._pixel_mask]
+        np.testing.assert_array_almost_equal(
+            rctd.nUMI, kept_umi,
+            err_msg="nUMI was recomputed after gene restriction (should stay as total UMI)"
+        )
+
+    def test_run_rctd_with_counts_min(self):
+        """run_rctd() convenience function should also apply counts_MIN."""
+        from rctd._rctd import run_rctd
+        from rctd._types import FullResult
+
+        spatial, ref_adata, n_normal, n_sparse = _make_counts_min_test_data()
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        # counts_MIN=0: should get more pixels
+        config_0 = RCTDConfig(UMI_min=100, counts_MIN=0)
+        res_0 = run_rctd(spatial, reference, mode="full", config=config_0, batch_size=10)
+        n_0 = res_0.weights.shape[0]
+
+        # counts_MIN=10: should get fewer pixels
+        config_10 = RCTDConfig(UMI_min=100, counts_MIN=10)
+        res_10 = run_rctd(spatial, reference, mode="full", config=config_10, batch_size=10)
+        n_10 = res_10.weights.shape[0]
+
+        assert n_10 < n_0, (
+            f"run_rctd with counts_MIN=10 ({n_10} pixels) should have fewer pixels "
+            f"than counts_MIN=0 ({n_0} pixels)"
+        )
+
+    def test_counts_min_with_doublet_mode(self):
+        """counts_MIN should work correctly with doublet mode too."""
+        from rctd._rctd import run_rctd
+        from rctd._types import DoubletResult
+
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        config = RCTDConfig(UMI_min=100, counts_MIN=10)
+        res = run_rctd(spatial, reference, mode="doublet", config=config, batch_size=10)
+
+        assert isinstance(res, DoubletResult)
+        # All result arrays should have same first dimension
+        assert res.weights.shape[0] == res.spot_class.shape[0]
+        assert res.weights.shape[0] == res.first_type.shape[0]
+
+    def test_cli_output_alignment_after_counts_min(self):
+        """CLI _write_results_to_adata should correctly expand filtered results."""
+        from rctd._rctd import RCTD, run_rctd
+        from rctd._types import RCTDConfig
+        from rctd.cli import _write_results_to_adata
+
+        spatial, ref_adata, _, _ = _make_counts_min_test_data()
+        reference = Reference(ref_adata, cell_min=10, min_UMI=10)
+
+        config = RCTDConfig(UMI_min=100, counts_MIN=10)
+        rctd = RCTD(spatial, reference, config)
+        rctd.fit_platform_effects()
+
+        from rctd._full import run_full_mode
+        result = run_full_mode(
+            spatial_counts=rctd.counts,
+            spatial_numi=rctd.nUMI,
+            norm_profiles=rctd.norm_profiles,
+            cell_type_names=rctd.reference.cell_type_names,
+            q_mat=rctd.q_mat,
+            sq_mat=rctd.sq_mat,
+            x_vals=rctd.x_vals,
+            batch_size=10,
+        )
+
+        out_adata = _write_results_to_adata(
+            spatial, result, "full", rctd._pixel_mask,
+            config._asdict(), rctd.reference.cell_type_names, "test"
+        )
+
+        # Output should have same number of obs as input
+        assert out_adata.n_obs == spatial.n_obs
+
+        # Filtered pixels should have NaN weights
+        n_filtered = (~rctd._pixel_mask).sum()
+        nan_rows = np.isnan(out_adata.obsm["rctd_weights"]).all(axis=1)
+        assert nan_rows.sum() == n_filtered, (
+            f"Expected {n_filtered} NaN rows, got {nan_rows.sum()}"
+        )
+
+        # Non-filtered pixels should have valid weights
+        valid_rows = ~nan_rows
+        assert valid_rows.sum() == rctd.counts.shape[0]
+        assert not np.isnan(out_adata.obsm["rctd_weights"][valid_rows]).any()

--- a/tests/test_counts_min.py
+++ b/tests/test_counts_min.py
@@ -11,7 +11,6 @@ rctd-py must replicate this behavior.
 
 import anndata
 import numpy as np
-import pytest
 
 from rctd._rctd import RCTD
 from rctd._reference import Reference
@@ -198,14 +197,14 @@ class TestCountsMinFilter:
         total_umi_all_genes = np.array(spatial.X.sum(axis=1)).flatten()
         kept_umi = total_umi_all_genes[rctd._pixel_mask]
         np.testing.assert_array_almost_equal(
-            rctd.nUMI, kept_umi,
-            err_msg="nUMI was recomputed after gene restriction (should stay as total UMI)"
+            rctd.nUMI,
+            kept_umi,
+            err_msg="nUMI was recomputed after gene restriction (should stay as total UMI)",
         )
 
     def test_run_rctd_with_counts_min(self):
         """run_rctd() convenience function should also apply counts_MIN."""
         from rctd._rctd import run_rctd
-        from rctd._types import FullResult
 
         spatial, ref_adata, n_normal, n_sparse = _make_counts_min_test_data()
         reference = Reference(ref_adata, cell_min=10, min_UMI=10)
@@ -243,7 +242,7 @@ class TestCountsMinFilter:
 
     def test_cli_output_alignment_after_counts_min(self):
         """CLI _write_results_to_adata should correctly expand filtered results."""
-        from rctd._rctd import RCTD, run_rctd
+        from rctd._rctd import RCTD
         from rctd._types import RCTDConfig
         from rctd.cli import _write_results_to_adata
 
@@ -255,6 +254,7 @@ class TestCountsMinFilter:
         rctd.fit_platform_effects()
 
         from rctd._full import run_full_mode
+
         result = run_full_mode(
             spatial_counts=rctd.counts,
             spatial_numi=rctd.nUMI,
@@ -267,8 +267,13 @@ class TestCountsMinFilter:
         )
 
         out_adata = _write_results_to_adata(
-            spatial, result, "full", rctd._pixel_mask,
-            config._asdict(), rctd.reference.cell_type_names, "test"
+            spatial,
+            result,
+            "full",
+            rctd._pixel_mask,
+            config._asdict(),
+            rctd.reference.cell_type_names,
+            "test",
         )
 
         # Output should have same number of obs as input
@@ -277,9 +282,7 @@ class TestCountsMinFilter:
         # Filtered pixels should have NaN weights
         n_filtered = (~rctd._pixel_mask).sum()
         nan_rows = np.isnan(out_adata.obsm["rctd_weights"]).all(axis=1)
-        assert nan_rows.sum() == n_filtered, (
-            f"Expected {n_filtered} NaN rows, got {nan_rows.sum()}"
-        )
+        assert nan_rows.sum() == n_filtered, f"Expected {n_filtered} NaN rows, got {nan_rows.sum()}"
 
         # Non-filtered pixels should have valid weights
         valid_rows = ~nan_rows

--- a/tests/test_pixel_mask.py
+++ b/tests/test_pixel_mask.py
@@ -2,10 +2,9 @@
 
 import anndata
 import numpy as np
-import pytest
 
-from rctd._reference import Reference
 from rctd._rctd import run_rctd
+from rctd._reference import Reference
 from rctd._types import RCTDConfig
 
 
@@ -17,9 +16,7 @@ def _make_test_data(n_spatial=50, n_ref=80, n_genes=100, n_types=3, seed=42):
     ref_counts = rng.poisson(5, (n_ref, n_genes)).astype(np.float32)
     ref_adata = anndata.AnnData(X=ref_counts)
     ref_adata.var_names = [f"Gene{i}" for i in range(n_genes)]
-    ref_adata.obs["cell_type"] = rng.choice(
-        [f"Type{i}" for i in range(n_types)], n_ref
-    )
+    ref_adata.obs["cell_type"] = rng.choice([f"Type{i}" for i in range(n_types)], n_ref)
     ref = Reference(ref_adata, cell_min=2)
 
     # Spatial — include some low-UMI pixels that will be filtered

--- a/tests/test_pixel_mask.py
+++ b/tests/test_pixel_mask.py
@@ -1,0 +1,135 @@
+"""Tests for pixel_mask field in result types."""
+
+import anndata
+import numpy as np
+import pytest
+
+from rctd._reference import Reference
+from rctd._rctd import run_rctd
+from rctd._types import RCTDConfig
+
+
+def _make_test_data(n_spatial=50, n_ref=80, n_genes=100, n_types=3, seed=42):
+    """Create minimal spatial + reference data for testing."""
+    rng = np.random.default_rng(seed)
+
+    # Reference
+    ref_counts = rng.poisson(5, (n_ref, n_genes)).astype(np.float32)
+    ref_adata = anndata.AnnData(X=ref_counts)
+    ref_adata.var_names = [f"Gene{i}" for i in range(n_genes)]
+    ref_adata.obs["cell_type"] = rng.choice(
+        [f"Type{i}" for i in range(n_types)], n_ref
+    )
+    ref = Reference(ref_adata, cell_min=2)
+
+    # Spatial — include some low-UMI pixels that will be filtered
+    spatial_counts = rng.poisson(10, (n_spatial, n_genes)).astype(np.float32)
+    # Make first 5 pixels very low UMI (will be filtered)
+    spatial_counts[:5] = rng.poisson(0.5, (5, n_genes)).astype(np.float32)
+    spatial = anndata.AnnData(X=spatial_counts)
+    spatial.var_names = [f"Gene{i}" for i in range(n_genes)]
+
+    return spatial, ref
+
+
+class TestPixelMaskFull:
+    """Test pixel_mask in full mode results."""
+
+    def test_pixel_mask_exists(self):
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="full", config=config)
+
+        assert hasattr(result, "pixel_mask")
+        assert result.pixel_mask is not None
+
+    def test_pixel_mask_dtype_and_shape(self):
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="full", config=config)
+
+        assert result.pixel_mask.dtype == bool
+        assert result.pixel_mask.shape == (spatial.n_obs,)
+
+    def test_pixel_mask_consistency(self):
+        """Sum of pixel_mask equals number of result rows."""
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="full", config=config)
+
+        assert result.pixel_mask.sum() == result.weights.shape[0]
+
+    def test_pixel_mask_filters_pixels(self):
+        """pixel_mask has fewer True entries than total pixels when filtering occurs."""
+        spatial, ref = _make_test_data()
+        # High UMI_min to ensure some filtering
+        config = RCTDConfig(UMI_min=50, compile=False)
+        result = run_rctd(spatial, ref, mode="full", config=config)
+
+        assert result.pixel_mask.sum() < spatial.n_obs
+
+    def test_pixel_mask_barcode_mapping(self):
+        """pixel_mask can map results back to original barcodes."""
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="full", config=config)
+
+        selected = spatial.obs_names[result.pixel_mask]
+        assert len(selected) == result.weights.shape[0]
+
+
+class TestPixelMaskDoublet:
+    """Test pixel_mask in doublet mode results."""
+
+    def test_pixel_mask_doublet(self):
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="doublet", config=config)
+
+        assert result.pixel_mask is not None
+        assert result.pixel_mask.dtype == bool
+        assert result.pixel_mask.sum() == result.weights.shape[0]
+
+
+class TestPixelMaskMulti:
+    """Test pixel_mask in multi mode results."""
+
+    def test_pixel_mask_multi(self):
+        spatial, ref = _make_test_data()
+        config = RCTDConfig(UMI_min=10, compile=False)
+        result = run_rctd(spatial, ref, mode="multi", config=config)
+
+        assert result.pixel_mask is not None
+        assert result.pixel_mask.dtype == bool
+        assert result.pixel_mask.sum() == result.weights.shape[0]
+
+
+class TestPixelMaskBackwardCompat:
+    """Test backward compatibility — pixel_mask defaults to None."""
+
+    def test_full_result_default_none(self):
+        from rctd._types import FullResult
+
+        result = FullResult(
+            weights=np.zeros((5, 3)),
+            cell_type_names=["A", "B", "C"],
+            converged=np.ones(5, dtype=bool),
+        )
+        assert result.pixel_mask is None
+
+    def test_doublet_result_default_none(self):
+        from rctd._types import DoubletResult
+
+        result = DoubletResult(
+            weights=np.zeros((5, 3)),
+            weights_doublet=np.zeros((5, 2)),
+            spot_class=np.zeros(5, dtype=int),
+            first_type=np.zeros(5, dtype=int),
+            second_type=np.zeros(5, dtype=int),
+            first_class=np.zeros(5, dtype=bool),
+            second_class=np.zeros(5, dtype=bool),
+            min_score=np.zeros(5),
+            singlet_score=np.zeros(5),
+            cell_type_names=["A", "B", "C"],
+        )
+        assert result.pixel_mask is None

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -142,3 +142,36 @@ class TestReference:
         # Profiles should still be valid and sum to ~1
         col_sums = ref.profiles.sum(axis=0)
         np.testing.assert_allclose(col_sums, np.ones(ref.n_types), atol=0.02)
+
+    @pytest.mark.parametrize("n_max_cells", [10_000, 50])
+    def test_sparse_matches_dense(self, n_max_cells):
+        """Sparse and dense inputs must produce identical profiles.
+
+        Tests both with and without downsampling (n_max_cells < cells/type).
+        """
+        import anndata
+        from scipy import sparse
+
+        rng = np.random.default_rng(42)
+        n_genes, n_cells = 100, 300
+        counts = rng.poisson(5, size=(n_cells, n_genes)).astype(np.float32)
+        cell_types = ["Type_A"] * 100 + ["Type_B"] * 100 + ["Type_C"] * 100
+
+        adata_dense = anndata.AnnData(
+            X=counts.copy(),
+            obs={"cell_type": cell_types},
+        )
+        adata_dense.var_names = [f"Gene_{i}" for i in range(n_genes)]
+        adata_dense.obs_names = [f"Cell_{i}" for i in range(n_cells)]
+
+        adata_sparse = anndata.AnnData(
+            X=sparse.csr_matrix(counts),
+            obs={"cell_type": cell_types},
+        )
+        adata_sparse.var_names = [f"Gene_{i}" for i in range(n_genes)]
+        adata_sparse.obs_names = [f"Cell_{i}" for i in range(n_cells)]
+
+        ref_dense = Reference(adata_dense, cell_type_col="cell_type", n_max_cells=n_max_cells)
+        ref_sparse = Reference(adata_sparse, cell_type_col="cell_type", n_max_cells=n_max_cells)
+
+        np.testing.assert_allclose(ref_sparse.profiles, ref_dense.profiles, rtol=1e-12)


### PR DESCRIPTION
## Summary

Bundles six user-reported issues into a single release:

| Issue | Fix |
|-------|-----|
| **#11** counts_MIN not applied | Enforce bulk-gene pixel filter in `fit_platform_effects()` |
| **#10** torch.compile fails without cuda.h | Lazy auto-detect with `RCTDConfig(compile=False)` escape hatch |
| **#8** Missing pixel index in results | Add `pixel_mask` field to all result types |
| **#9** VisiumHD workflow (same as #8) | Same fix — `result.pixel_mask` maps results to barcodes |
| **tjli** cuSOLVER eigh crash at batch>30k | `_eigh_safe()` sub-batches at 25k |
| **Memory** OOM on 370k-cell references | Sparse-aware profile computation |

Also includes: `_longdouble_sum()` for R numerical precision parity.

### Breaking changes

- `FullResult`, `DoubletResult`, `MultiResult` gain a `pixel_mask` field (default `None` for backward compat)
- `RCTDConfig` gains a `compile` field (default `True`)
- `counts_MIN=10` is now enforced (was declared but ignored) — result pixel counts will differ from v0.2.x

### New CLI flags

- `--no-compile`: disable torch.compile for environments without CUDA headers

## Test plan

- [x] 100/100 tests pass (76 existing + 9 counts_MIN + 9 compile fallback + 9 pixel_mask - 3 overlap)
- [x] ruff check + format clean
- [x] Region 1 Xenium validation: 13,936 pixels (exact match with R spacexr)
- [x] Region 3 Xenium validation: 58,187 pixels, dominant_type_agreement=0.9972

🤖 Generated with [Claude Code](https://claude.com/claude-code)