### PR TITLE
Fix CI/CD workflow gaps surfaced by v0.3.2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
         run: uv pip install --system ".[dev]"
 
       - name: Run unit tests
-        run: pytest tests/ -v --cov=rctd --cov-report=xml -m "not slow"
+        run: pytest tests/ -v -m "not slow"
 
-      - name: Run R concordance tests
-        run: pytest tests/test_concordance.py -v -m slow
+      - name: Run slow integration + R concordance tests
+        run: pytest tests/ -v -m slow
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - "v*.*.*"
@@ -13,7 +11,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,3 +31,28 @@ jobs:
 
       - name: Publish to PyPI
         run: uv publish --check-url https://pypi.org/simple/rctd-py/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF##*/}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $tag already exists, skipping."
+            exit 0
+          fi
+          # Extract the section for this version from CHANGELOG.md (between "## [x.y.z]" and the next "## [")
+          notes_file="$(mktemp)"
+          awk -v tag="${tag#v}" '
+            $0 ~ "^## \\[" tag "\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > "$notes_file"
+          if [ ! -s "$notes_file" ]; then
+            echo "No CHANGELOG entry found for $tag; creating release with empty notes."
+          fi
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$tag" \
+            --notes-file "$notes_file" \
+            ./dist/*


### PR DESCRIPTION
publish.yml:
- Drop the duplicate `release.published` trigger. With both
  `release.published` and `push.tags: v*.*.*` configured, releases that
  also pushed a tag triggered the workflow twice (e.g. v0.3.0 produced
  two parallel publish runs; only `--check-url` prevented PyPI
  rejection).
- Auto-create a GitHub Release on tag push using `gh release create`,
  pulling notes from the matching CHANGELOG.md section and uploading
  the built sdist + wheel. v0.3.2 was published to PyPI and tagged but
  never got a corresponding GitHub Release entity.

ci.yml:
- Drop `--cov=rctd --cov-report=xml`; the codecov upload was removed in
  v0.2.0, so the coverage report goes nowhere.
- Run all `slow`-marked tests (`pytest tests/ -v -m slow`) instead of
  only `tests/test_concordance.py`. The 7 CLI integration tests in
  `test_cli.py` are also marked `slow` and were silently skipped.