### PR TITLE
fix(_psd_batch): guard CPU eigh against non-finite & singular batches (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to rctd-py are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] — 2026-05-29
+
+### Fixed
+- **`_LinAlgError` crash in doublet mode at K≈49 on the CPU eigh path** (reported by @EduardGhemes-ICR, #20). `_psd_batch` previously called `torch.linalg.eigh` raw on the CPU branch; a single non-finite or near-degenerate batch element would crash LAPACK `syevd` with "error code: 99" and kill multi-hour Xenium runs. The CPU branch now mirrors the GPU branch's NaN guard (extended to ±Inf) and adds a small-diagonal-jitter retry ladder (1e-6 → 1e-4 → ε·I last resort). Happy-path output is bit-identical to v0.3.2 — only previously-crashing inputs are affected. Triggered most often on older arches (Volta / Turing / Ampere / Ada / L40S) where K > 16 falls through to CPU eigh, but the guard is unconditional and applies to CPU-only deployments as well.
+
 ## [0.3.2] — 2026-05-02
 
 ### Added

--- a/src/rctd/_irwls.py
+++ b/src/rctd/_irwls.py
@@ -351,7 +351,36 @@ def _psd_batch(H: torch.Tensor, epsilon: float = 1e-3) -> tuple[torch.Tensor, to
         orig_device = H.device
         orig_dtype = H.dtype
         H_cpu = H if H.device.type == "cpu" else H.cpu()
-        eigenvalues, eigenvectors = torch.linalg.eigh(H_cpu)
+
+        # Guard: LAPACK syevd raises "_LinAlgError (error code: 99)" on
+        # non-finite or near-degenerate batches (issue #20 — K=49 doublet
+        # mode on Xenium MINOR types). Mirror the GPU branch's NaN guard,
+        # extended to ±Inf.
+        bad_mask = (~torch.isfinite(H_cpu)).any(dim=-1).any(dim=-1)  # (N,)
+        if bad_mask.any():
+            H_cpu = H_cpu.clone()
+            H_cpu[bad_mask] = epsilon * torch.eye(K, dtype=H_cpu.dtype)
+
+        try:
+            eigenvalues, eigenvectors = torch.linalg.eigh(H_cpu)
+        except torch._C._LinAlgError:
+            # Add a tiny diagonal jitter and retry. Jitter << epsilon clamp
+            # (1e-3), so well-conditioned batch elements are unaffected after
+            # the clamp below.
+            I_K = torch.eye(K, dtype=H_cpu.dtype)
+            for jitter in (1e-6, 1e-4):
+                try:
+                    eigenvalues, eigenvectors = torch.linalg.eigh(H_cpu + jitter * I_K)
+                    break
+                except torch._C._LinAlgError:
+                    continue
+            else:
+                # Last resort: replace the whole batch with epsilon*I. The IRWLS
+                # outer loop handles the resulting near-zero delta_w gracefully
+                # (same contract as the GPU NaN path above).
+                H_safe = (epsilon * I_K).expand_as(H_cpu).contiguous()
+                eigenvalues, eigenvectors = torch.linalg.eigh(H_safe)
+
         eigenvalues = torch.clamp(eigenvalues, min=epsilon)
         H_psd = eigenvectors @ torch.diag_embed(eigenvalues) @ eigenvectors.transpose(-1, -2)
         max_eig = eigenvalues[:, -1]

--- a/tests/test_blackwell_perf.py
+++ b/tests/test_blackwell_perf.py
@@ -96,6 +96,56 @@ def test_psd_batch_cpu_path_unchanged():
     np.testing.assert_allclose(max_eig.numpy(), eig_ref.numpy(), atol=1e-9, rtol=1e-9)
 
 
+# ─── _psd_batch CPU robustness (issue #20) ──────────────────────────────
+
+
+def test_psd_batch_cpu_handles_non_finite():
+    """NaN/Inf in any batch element must not crash the CPU eigh path.
+
+    Reported by @EduardGhemes-ICR in #20: K=49 doublet mode on a 280-gene
+    Xenium panel crashed with LAPACK ``_LinAlgError`` ("error code: 99")
+    inside ``_psd_batch``. The GPU branch already guarded against NaN via
+    ``epsilon*I`` replacement; the CPU branch did not.
+    """
+    K = 49
+    H = _make_psd_batch(N=8, K=K, seed=42)
+    H[3, 0, 0] = float("nan")
+    H[5, 10, 10] = float("inf")
+    H_psd, max_eig = _psd_batch(H)
+    assert torch.isfinite(H_psd).all()
+    assert torch.isfinite(max_eig).all()
+    # All batch elements clamped at epsilon=1e-3
+    assert (max_eig >= 1e-3 - 1e-9).all()
+
+
+def test_psd_batch_cpu_retries_on_linalg_error(monkeypatch):
+    """The CPU branch must recover from a transient LAPACK ``_LinAlgError``
+    via a small-diagonal-jitter retry (issue #20). We can't reliably trip
+    ``syevd``'s "error code: 99" with synthetic inputs across LAPACK builds,
+    so we simulate it by intercepting ``torch.linalg.eigh`` once."""
+    K = 49
+    H = _make_psd_batch(N=8, K=K, seed=7)
+
+    real_eigh = torch.linalg.eigh
+    state = {"calls": 0}
+
+    def flaky_eigh(M):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise torch._C._LinAlgError(
+                "linalg.eigh: (Batch element 2): The algorithm failed to converge "
+                "because the input matrix is ill-conditioned or has too many "
+                "repeated eigenvalues (error code: 99)."
+            )
+        return real_eigh(M)
+
+    monkeypatch.setattr(torch.linalg, "eigh", flaky_eigh)
+    H_psd, max_eig = _psd_batch(H)
+    assert torch.isfinite(H_psd).all()
+    assert torch.isfinite(max_eig).all()
+    assert state["calls"] >= 2  # initial + at least one jitter retry
+
+
 # ─── Box-QP equivalence: eager vs JIT ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #20 — `_LinAlgError ("error code: 99")` crash in doublet mode at K≈49 on the CPU `eigh` path, reported by @EduardGhemes-ICR (ICR) on a 280-gene Xenium panel with 49 minor cell types.

Root cause: the **GPU branch** of [`_psd_batch`](https://github.com/p-gueguen/rctd-py/blob/main/src/rctd/_irwls.py#L314-L362) already guards NaN inputs by replacing them with `ε·I` before `eigh` (L337–340). The **CPU branch** (L353) called `torch.linalg.eigh` raw — any single non-finite or near-degenerate batch element would crash LAPACK `syevd` and kill a multi-hour Xenium run.

Most users on Hopper / Blackwell (sm_90+) are unaffected because K=49 stays on the GPU eigh path (per-arch threshold = 128). The bug bites on Volta / Turing / Ampere / Ada / L40S (sm_8x) where K > 16 falls through to CPU eigh, and on CPU-only deployments.

## Changes

- **`src/rctd/_irwls.py`** — patch the CPU branch of `_psd_batch`:
  - Pre-`eigh`: replace non-finite (NaN or ±Inf) batch elements with `ε·I`. Mirrors the GPU branch's pattern, widened from `isnan` to `~isfinite`.
  - Wrap `torch.linalg.eigh` in a jitter retry ladder (`1e-6 → 1e-4 → ε·I` last resort) for transient LAPACK convergence failures. Jitter ≪ ε clamp (`1e-3`), so well-conditioned batch elements are unaffected after the existing clamp.
- **`tests/test_blackwell_perf.py`** — two new regression tests:
  - `test_psd_batch_cpu_handles_non_finite` — empirical: NaN + Inf in batch at K=49 → finite output.
  - `test_psd_batch_cpu_retries_on_linalg_error` — monkeypatches `torch.linalg.eigh` to raise the exact error-99 message once, asserts jitter retry recovers.
- **`CHANGELOG.md`** — `## [0.3.3]` entry under "Fixed".

## Verification

- ✅ Both new tests **fail** on `main` (TDD red), **pass** on this branch (TDD green).
- ✅ Existing `test_psd_batch_cpu_path_unchanged` at K=78 still passes at `atol=1e-9` — happy-path output is bit-identical to v0.3.2.
- ✅ Full `test_blackwell_perf.py` — 25 passed, 1 skipped (GPU-only).
- ✅ Full pytest suite — 137 passed, 1 skipped.
- ✅ Slow R-vs-Python concordance suite — 3 passed (`pytest tests/test_concordance.py -m slow`).
- ✅ `ruff check` and `ruff format --check` clean.

## Test plan

- [x] `uv run pytest tests/test_blackwell_perf.py -k "non_finite or retries_on_linalg"` — both pass
- [x] `uv run pytest tests/test_blackwell_perf.py -k psd_batch` — 3 pass + 1 skip (no regression at K=78)
- [x] `uv run pytest` — full suite green
- [x] `uv run pytest tests/test_concordance.py -m slow` — R concordance green
- [x] `uv run ruff check` + `ruff format --check` — clean

## Out of scope

- GPU branch — already guards NaN, not affected by the report.
- New public API. The retry is internal; only externally visible change is "no longer crashes."
- Bumping `_cuda_eigh_threshold` for Ampere/L40S — perf decision, orthogonal to this correctness fix.
- v0.3.3 tag — leaving to you, per project tag-driven release policy (`.github/workflows/publish.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)