### PR TITLE
feat(eigh): add --eigh-threshold CLI override for _psd_batch K cutoff (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to rctd-py are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`--eigh-threshold` CLI flag and `RCTDConfig.eigh_threshold`** (reported by @meisproject, #22). Manually override the K cutoff for staying on GPU eigh inside `_psd_batch`. The arch-based default (`K≤16` on sm_<9, `K≤128` on sm_≥9) was derived from L40S benchmarks at K=45 where CPU OpenBLAS won — but only with `OMP_NUM_THREADS` capped. Users on Volta (V100, sm_70), Turing, Ampere, or Ada (L20/L40S, sm_89) who hit Step 1 perf cliffs at K∈[17, 64] (e.g. K=38 reported at 3086 s for 6113 pixels) can now force GPU eigh via `--eigh-threshold 64` without waiting on a per-arch benchmark / release. Setting `--eigh-threshold 0` forces CPU eigh on every arch (diagnostic counter-case). Default `None` preserves v0.3.3 arch-gated behavior bit-for-bit.
+
 ## [0.3.3] — 2026-05-29
 
 ### Fixed

--- a/src/rctd/_irwls.py
+++ b/src/rctd/_irwls.py
@@ -293,6 +293,11 @@ def _eigh_safe(H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return torch.cat(all_evals), torch.cat(all_evecs)
 
 
+# User override for the GPU-eigh K cutoff. None = arch-based default.
+# Set by RCTD.__init__ from RCTDConfig.eigh_threshold (issue #22).
+_EIGH_THRESHOLD_OVERRIDE: int | None = None
+
+
 def _cuda_eigh_threshold(device: torch.device) -> int:
     """Per-arch K threshold for staying on GPU eigh vs offloading to CPU OpenBLAS.
 
@@ -301,9 +306,15 @@ def _cuda_eigh_threshold(device: torch.device) -> int:
     and Blackwell (sm_100+), cuSOLVER's batched eigh is much faster, and
     CPU offload causes a major perf cliff (8h+ stalls observed at K=78).
     Bump the threshold on newer arches.
+
+    If ``_EIGH_THRESHOLD_OVERRIDE`` is set, it wins over the arch default —
+    e.g. ``--eigh-threshold 64`` on V100/L20 to force GPU eigh at K=38
+    instead of falling into the (often slower) CPU offload path.
     """
     if device.type != "cuda":
         return 0
+    if _EIGH_THRESHOLD_OVERRIDE is not None:
+        return _EIGH_THRESHOLD_OVERRIDE
     try:
         major, _ = torch.cuda.get_device_capability(device)
     except Exception:

--- a/src/rctd/_rctd.py
+++ b/src/rctd/_rctd.py
@@ -50,6 +50,12 @@ class RCTD:
             _irwls._USE_COMPILE = False
             _likelihood._CALC_Q_USE_COMPILE = False
 
+        # Apply user-supplied GPU-eigh K cutoff override (issue #22).
+        if self.config.eigh_threshold is not None:
+            from rctd import _irwls
+
+            _irwls._EIGH_THRESHOLD_OVERRIDE = int(self.config.eigh_threshold)
+
         # Internal state
         self.is_normalized = False
         self.norm_profiles = None

--- a/src/rctd/_types.py
+++ b/src/rctd/_types.py
@@ -32,6 +32,11 @@ class RCTDConfig(NamedTuple):
     device: str = "auto"  # "auto", "cpu", or "cuda"; auto uses GPU if available
     compile: bool = True  # Use torch.compile; False forces eager mode
     class_df: dict[str, str] | None = None  # Doublet mode: cell_type -> class; None = identity
+    # Override the per-arch K cutoff for staying on GPU eigh in _psd_batch.
+    # None = use arch-based default (K<=16 on sm_<9, K<=128 on sm_>=9). Set
+    # higher to force GPU eigh on older arches when the CPU offload is the
+    # bottleneck (issue #22 — K=38 on V100/L20). Ignored on CPU runs.
+    eigh_threshold: int | None = None
 
 
 def resolve_device(device: str = "auto") -> torch.device:

--- a/src/rctd/cli.py
+++ b/src/rctd/cli.py
@@ -411,6 +411,17 @@ def _write_results_to_adata(
     default=False,
     help="Disable torch.compile (for environments without CUDA headers).",
 )
+@click.option(
+    "--eigh-threshold",
+    default=None,
+    type=int,
+    help=(
+        "Override the K cutoff for GPU eigh in _psd_batch. K<=threshold stays "
+        "on GPU; K>threshold offloads to CPU LAPACK. Default is arch-based "
+        "(16 on sm_<9, 128 on sm_>=9). Bump (e.g. 64) on Volta/Turing/Ampere/"
+        "Ada when the CPU offload is the bottleneck (issue #22)."
+    ),
+)
 # Performance
 @click.option(
     "--batch-size",
@@ -478,6 +489,7 @@ def run(
     dtype,
     device,
     no_compile,
+    eigh_threshold,
     batch_size,
     sigma_override,
     cell_min,
@@ -535,6 +547,7 @@ def run(
         device=device,
         compile=not no_compile,
         class_df=class_df_dict,
+        eigh_threshold=eigh_threshold,
     )
     config_dict = config._asdict()
 

--- a/tests/test_blackwell_perf.py
+++ b/tests/test_blackwell_perf.py
@@ -75,6 +75,65 @@ def test_cuda_eigh_threshold_falls_back_safely_on_capability_error():
         assert _cuda_eigh_threshold(fake_cuda) == 16
 
 
+# ─── User override via RCTDConfig.eigh_threshold (issue #22) ─────────────
+
+
+@pytest.fixture
+def _reset_eigh_override():
+    """Restore the module-level override after each override test."""
+    from rctd import _irwls
+
+    original = _irwls._EIGH_THRESHOLD_OVERRIDE
+    yield
+    _irwls._EIGH_THRESHOLD_OVERRIDE = original
+
+
+def test_eigh_threshold_override_wins_over_arch_default(_reset_eigh_override):
+    """When ``_EIGH_THRESHOLD_OVERRIDE`` is set, it must replace the arch-based
+    return value on CUDA devices (issue #22 — bump K cutoff on Volta/Ada)."""
+    from rctd import _irwls
+
+    fake_cuda = torch.device("cuda")
+    # Pretend we're on Ampere A100 (arch default would be 16).
+    with patch("torch.cuda.get_device_capability", return_value=(8, 0)):
+        assert _cuda_eigh_threshold(fake_cuda) == 16
+        _irwls._EIGH_THRESHOLD_OVERRIDE = 64
+        assert _cuda_eigh_threshold(fake_cuda) == 64
+        _irwls._EIGH_THRESHOLD_OVERRIDE = 0  # 0 = force CPU eigh always
+        assert _cuda_eigh_threshold(fake_cuda) == 0
+
+
+def test_eigh_threshold_override_ignored_on_cpu(_reset_eigh_override):
+    """CPU device must still return 0 even with an override set — there is no
+    GPU dispatch path on CPU, so the override is a no-op there."""
+    from rctd import _irwls
+
+    _irwls._EIGH_THRESHOLD_OVERRIDE = 999
+    assert _cuda_eigh_threshold(torch.device("cpu")) == 0
+
+
+def test_eigh_threshold_override_force_cpu_on_capable_arch(_reset_eigh_override):
+    """Setting override=0 forces CPU eigh even on Hopper/Blackwell (where the
+    arch default of 128 would have kept eigh on GPU). Lets users diagnose
+    suspected cuSOLVER bugs without rebuilding."""
+    from rctd import _irwls
+
+    fake_cuda = torch.device("cuda")
+    with patch("torch.cuda.get_device_capability", return_value=(10, 0)):
+        assert _cuda_eigh_threshold(fake_cuda) == 128
+        _irwls._EIGH_THRESHOLD_OVERRIDE = 0
+        assert _cuda_eigh_threshold(fake_cuda) == 0
+
+
+def test_rctd_config_carries_eigh_threshold_field():
+    """``RCTDConfig`` must expose ``eigh_threshold`` for CLI/API users and
+    default to ``None`` (= arch-based behavior)."""
+    from rctd._types import RCTDConfig
+
+    assert RCTDConfig().eigh_threshold is None
+    assert RCTDConfig(eigh_threshold=64).eigh_threshold == 64
+
+
 # ─── _psd_batch CPU path preservation ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Add `RCTDConfig.eigh_threshold` (default `None`) + matching `--eigh-threshold INT` CLI flag.
- Lets users override the per-arch K cutoff that decides GPU eigh vs CPU LAPACK offload inside `_psd_batch`.
- Wires through `RCTD.__init__` in the same module-attribute-set style as the existing `_USE_COMPILE` plumbing — no new function signatures.

## Why

Closes #22. @meisproject reported Step 1 (full-mode fit) on Tesla V100 (sm_70) taking 3086 s for 6113 pixels at K=38 — a ~50× slowdown vs the rest of the pipeline (Steps 3–6 total 38 s). Same pattern reproducible on L20 (sm_89). Root cause is the arch-gated K=16 cutoff in `_psd_batch`: any K>16 on `major<9` arches falls into the unguarded CPU eigh path, and without `OMP_NUM_THREADS=1` the unbounded OpenBLAS spawn stalls the IRWLS loop.

The historical K=16 cutoff was derived from L40S benchmarks at K=45 where CPU OpenBLAS *did* win — but only with BLAS threads capped. Without re-benchmarking V100 / L20 / Ampere across K=17..64 (and with vs without thread caps), we can't responsibly change the default. **This PR ships the manual escape hatch instead**: `--eigh-threshold 64` forces K≤64 onto GPU eigh, `--eigh-threshold 0` forces CPU eigh everywhere (diagnostic), and the default `None` keeps v0.3.3 behavior bit-for-bit.

## What changes (and what doesn't)

| File | Change |
|---|---|
| `src/rctd/_types.py` | New `RCTDConfig.eigh_threshold: int \| None = None` field |
| `src/rctd/_irwls.py` | Module-level `_EIGH_THRESHOLD_OVERRIDE`; `_cuda_eigh_threshold` checks it first |
| `src/rctd/_rctd.py` | `RCTD.__init__` sets `_irwls._EIGH_THRESHOLD_OVERRIDE` when config field is non-None |
| `src/rctd/cli.py` | `--eigh-threshold INT` flag, plumbed into `RCTDConfig` |
| `tests/test_blackwell_perf.py` | 4 new tests: override wins over arch default, ignored on CPU, force-CPU on capable arch, RCTDConfig field exposure |

**Default behavior unchanged.** With `--eigh-threshold` unset / `RCTDConfig.eigh_threshold=None`, `_cuda_eigh_threshold` returns exactly what it did in v0.3.3 (16 on sm_<9, 128 on sm_≥9). No happy-path divergence.

## Test plan

- [x] `uv run pytest tests/test_blackwell_perf.py -k "eigh_threshold or rctd_config_carries" -v` → 4/4 pass
- [x] `uv run pytest tests/test_blackwell_perf.py` → 29 passed, 1 skipped (no GPU regression)
- [x] Full suite minus slow R-concordance → 138 passed, 1 skipped, in 193 s
- [x] `uv run rctd run --help` shows new flag with the expected help text
- [ ] Manual repro on a Volta/Ada node — out of scope here; @meisproject is best-placed to run it

## Notes for #22

Recommended user incantation while waiting for a release tag:

```bash
git clone -b feat/eigh-threshold-override https://github.com/p-gueguen/rctd-py.git
cd rctd-py && uv pip install -e .
OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
  rctd run ... --eigh-threshold 64 --no-compile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)